### PR TITLE
Keep connection closed after close()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,10 @@ const ReconnectingWebsocket = function(
     };
 
     const connect = () => {
+        if (!shouldRetry) {
+            return;
+        }
+
         log('connect');
         const oldWs = ws;
         ws = new (<any>config.constructor)(url, protocols);


### PR DESCRIPTION
If close() is called after handleClose() and before connect() (while the underlying WebSocket is closed), the WebSocket will be reopened again after the reconnectDelay timeout expires.

To prevent this, check shouldRetry after the reconnectDelay timeout expires to determine whether the WebSocket should be reopened.

My particular use case is: I would like to stop reconnecting if a particular WebSocket Close Status Code is received from the server.  The obvious solution was:
```
var checkClose = function(event) {
  if(event.code == 4000) {
    rcws.removeEventListener('close', checkClose);
    rcws.close(event.code, undefined, {keepClosed: true, fastClose: true});
  }
};
rcws.addEventListener('close', checkClose);
```
However, this doesn't work as expected because handleClose() is called before my checkClose() function and there is no way for me to cancel the reconnectDelay timer to prevent ReconnectingWebsocket from reconnecting after I call rcws.close().  This commit fixes this issue.