### PR TITLE
Fix 'open' event listener overriding previously initialized reconnectDelay

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -136,12 +136,7 @@ var ReconnectingWebsocket = function (url, protocols, options) {
         ws.addEventListener('open', function () {
             clearTimeout(connectingTimeout);
             log('open');
-            if (!reconnectDelay) {
-                reconnectDelay = initReconnectionDelay(config);
-            }
-            else {
-                reconnectDelay = updateReconnectionDelay(config, reconnectDelay);
-            }
+            reconnectDelay = initReconnectionDelay(config);
             log('reconnectDelay:', reconnectDelay);
             retriesCount = 0;
         });
@@ -216,5 +211,6 @@ var ReconnectingWebsocket = function (url, protocols, options) {
         }
         ws.removeEventListener(type, listener, options);
     };
+    return this;
 };
 module.exports = ReconnectingWebsocket;

--- a/dist/index.js
+++ b/dist/index.js
@@ -136,7 +136,12 @@ var ReconnectingWebsocket = function (url, protocols, options) {
         ws.addEventListener('open', function () {
             clearTimeout(connectingTimeout);
             log('open');
-            reconnectDelay = initReconnectionDelay(config);
+            if (!reconnectDelay) {
+                reconnectDelay = initReconnectionDelay(config);
+            }
+            else {
+                reconnectDelay = updateReconnectionDelay(config, reconnectDelay);
+            }
             log('reconnectDelay:', reconnectDelay);
             retriesCount = 0;
         });

--- a/index.ts
+++ b/index.ts
@@ -130,11 +130,11 @@ const ReconnectingWebsocket = function(
             emitError('EHOSTDOWN', 'Too many failed connection attempts');
             return;
         }
-        if (!reconnectDelay) {
-            reconnectDelay = initReconnectionDelay(config);
-        } else {
-            reconnectDelay = updateReconnectionDelay(config, reconnectDelay);
-        }
+        // if (!reconnectDelay) {
+        reconnectDelay = initReconnectionDelay(config);
+        // } else {
+        //     reconnectDelay = updateReconnectionDelay(config, reconnectDelay);
+        // }
         log('handleClose - reconnectDelay:', reconnectDelay);
 
         if (shouldRetry) {
@@ -169,7 +169,12 @@ const ReconnectingWebsocket = function(
         ws.addEventListener('open', () => {
             clearTimeout(connectingTimeout);
             log('open');
-            reconnectDelay = initReconnectionDelay(config);
+            // reconnectDelay = initReconnectionDelay(config);
+            if (!reconnectDelay) {
+                reconnectDelay = initReconnectionDelay(config);
+            } else {
+                reconnectDelay = updateReconnectionDelay(config, reconnectDelay);
+            }
             log('reconnectDelay:', reconnectDelay);
             retriesCount = 0;
         });

--- a/index.ts
+++ b/index.ts
@@ -130,11 +130,7 @@ const ReconnectingWebsocket = function(
             emitError('EHOSTDOWN', 'Too many failed connection attempts');
             return;
         }
-        // if (!reconnectDelay) {
         reconnectDelay = initReconnectionDelay(config);
-        // } else {
-        //     reconnectDelay = updateReconnectionDelay(config, reconnectDelay);
-        // }
         log('handleClose - reconnectDelay:', reconnectDelay);
 
         if (shouldRetry) {
@@ -169,7 +165,6 @@ const ReconnectingWebsocket = function(
         ws.addEventListener('open', () => {
             clearTimeout(connectingTimeout);
             log('open');
-            // reconnectDelay = initReconnectionDelay(config);
             if (!reconnectDelay) {
                 reconnectDelay = initReconnectionDelay(config);
             } else {


### PR DESCRIPTION
Previously the `updateReconnectionDelay` function was always being overridden by `initReconnectionDelay` within the 'open' event listener when the connection was being disconnected. 

This meant that the `reconnectionDelayGrowFactor` functionality was not working, and the reconnection attempt would run according to the logic in `initReconnectionDelay` only.

To test, connect to a websocket using broken auth (or have the websocket server always close the connection some other way), using these options: 

```javascript
url = 'wss://websocket.com/your-uri';

const options = {
  debug: true,
  minReconnectionDelay: 500,
  maxReconnectionDelay: 600000,
  maxRetries: Infinity,
  reconnectionDelayGrowFactor: 1.3,
};

new ReconnectingWebSocket(url, undefined, options);
```

Previous behavior was for `reconnectionDelayGrowFactor` to be ignored.