### PR TITLE
Fixed missing parameter for extended "close" event

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 interface ReconnectingWebsocket extends WebSocket {
     [key: string]: any;
+    close(code?: number, reason?: string, config?: {keepClosed: boolean, fastClose: boolean, delay: number}): void;
 }
 declare const ReconnectingWebsocket: (url: string | (() => string), protocols?: string | string[], options?: {
     [key: string]: any;


### PR DESCRIPTION
`ReconnectingWebsocket` extends the WebSocket's `close` event by a third parameter (for additional configuration): https://github.com/pladaria/reconnecting-websocket/blob/v3.2.1/index.ts#L189

I added the specifics of this config parameter to the definition file to make it available for code which is using `ReconnectingWebsocket`.