### PR TITLE
reconnecting and reconnectscheduled custom events

### DIFF
--- a/dist/reconnecting-websocket.amd.js
+++ b/dist/reconnecting-websocket.amd.js
@@ -36,9 +36,10 @@ define("index", ["require", "exports"], function (require, exports) {
             : newDelay;
     };
     var LEVEL_0_EVENTS = ['onopen', 'onclose', 'onmessage', 'onerror'];
+    var LEVEL_1_EVENTS = ['open', 'close', 'message', 'error'];
     var reassignEventListeners = function (ws, oldWs, listeners) {
-        Object.keys(listeners).forEach(function (type) {
-            listeners[type].forEach(function (_a) {
+        LEVEL_1_EVENTS.forEach(function (type) {
+            (listeners[type] || []).forEach(function (_a) {
                 var listener = _a[0], options = _a[1];
                 ws.addEventListener(type, listener, options);
             });
@@ -58,6 +59,7 @@ define("index", ["require", "exports"], function (require, exports) {
         var retriesCount = 0;
         var shouldRetry = true;
         var savedOnClose = null;
+        var nextReconnectImmediate = false;
         var listeners = {};
         // require new to construct
         if (!(this instanceof ReconnectingWebsocket)) {
@@ -111,8 +113,22 @@ define("index", ["require", "exports"], function (require, exports) {
             }
             log('handleClose - reconnectDelay:', reconnectDelay);
             if (shouldRetry) {
-                setTimeout(connect, reconnectDelay);
+                if (nextReconnectImmediate) {
+                    connect();
+                }
+                else {
+                    setTimeout(connect, reconnectDelay);
+                    var event_1 = { detail: reconnectDelay };
+                    fireEventListeners('reconnectscheduled', event_1);
+                }
             }
+        };
+        var fireEventListeners = function (type, event) {
+            var listenerConfig = listeners[type] || [];
+            listenerConfig.forEach(function (_a) {
+                var listener = _a[0];
+                return listener(event);
+            });
         };
         var connect = function () {
             if (!shouldRetry) {
@@ -121,6 +137,7 @@ define("index", ["require", "exports"], function (require, exports) {
             log('connect');
             var oldWs = ws;
             var wsUrl = (typeof url === 'function') ? url() : url;
+            fireEventListeners('reconnecting', {});
             ws = new config.constructor(wsUrl, protocols);
             connectingTimeout = setTimeout(function () {
                 log('timeout');

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,6 @@ test.cb('max retries', t => {
     const ws = new RWS(url, null, {
         constructor: HWS,
         maxRetries: 2,
-        reconnectionDelayFactor: 0,
         maxReconnectionDelay: 0,
         minReconnectionDelay: 0,
     });
@@ -82,7 +81,6 @@ test.cb('level0 event listeners are reassigned after reconnect', t => {
     const ws = new RWS(url, null, {
         constructor: HWS,
         maxRetries: 4,
-        reconnectionDelayFactor: 1.2,
         maxReconnectionDelay: 20,
         minReconnectionDelay: 10,
     });
@@ -126,7 +124,6 @@ test.cb('level0 event listeners are reassigned after closing with fastClose', t 
 
     const ws = new RWS(url, null, {
         constructor: HWS,
-        reconnectionDelayFactor: 1.2,
         maxReconnectionDelay: 20,
         minReconnectionDelay: 10,
     });
@@ -163,7 +160,6 @@ test.cb('level2 event listeners (addEventListener, removeEventListener)', t => {
     const ws = new RWS(url, null, {
         constructor: HWS,
         maxRetries: 3,
-        reconnectionDelayFactor: 1.2,
         maxReconnectionDelay: 60,
         minReconnectionDelay: 11,
     });
@@ -404,3 +400,44 @@ test.cb('#14 fix - closing with keepClose before open', t => {
         t.end();
     }, 1000);
 });
+
+test.cb('reconnectScheduled eventListener is called', t => {
+    const wss = new WSS({port: PORT});
+    wss.on('connection', ws =>  wss.close());
+
+    const reconnectScheduled = (e) => {
+        t.is(e.detail, 10)
+        t.pass('reconnectScheduled called');
+        wss.close();
+        t.end();
+    }
+
+    const ws = new RWS(url, null, {
+        constructor: HWS,
+        maxRetries: 1,
+        reconnectionDelayGrowFactor: 1.0,
+        maxReconnectionDelay: 10,
+        minReconnectionDelay: 10,
+    });
+    ws.addEventListener('reconnectscheduled', reconnectScheduled);
+})
+
+test.cb('reconnecting eventListener is called', t => {
+    const wss = new WSS({port: PORT});
+    wss.on('connection', ws =>  wss.close());
+
+    const reconnecting = () => {
+        t.pass('reconnecting called');
+        wss.close();
+        t.end();
+    }
+
+    const ws = new RWS(url, null, {
+        constructor: HWS,
+        maxRetries: 1,
+        reconnectionDelayGrowFactor: 1.0,
+        maxReconnectionDelay: 10,
+        minReconnectionDelay: 10,
+    });
+    ws.addEventListener('reconnecting', reconnecting);
+})


### PR DESCRIPTION
Added two custom events:

1) `reconnecting` which fires immediately before the the underlying websocket is created
2) `reconnectscheduled` which fires when the next reconnect is scheduled and gives developers access to the delay value (so UIs like "Reconnecting in X seconds..." can be built more easily).

Related issues: https://github.com/pladaria/reconnecting-websocket/issues/28 and https://github.com/pladaria/reconnecting-websocket/issues/38
