### PR TITLE
fixed multiple ws open

### DIFF
--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -387,7 +387,7 @@ export default class ReconnectingWebSocket {
 
     private _handleError(event: ErrorEvent) {
         this._debug('error event', event.message);
-        this._disconnect(undefined, event.message === 'TIMEOUT' ? 'timeout' : undefined);
+        this._disconnect(4008, event.message === 'TIMEOUT' ? 'timeout' : undefined);
 
         if (this.onerror) {
             this.onerror(event);


### PR DESCRIPTION
Disconnecting with undefined as code causes the close method to crash. When trying to reconnect after a lost connection, this can cause several WebSockets to remain opened at the same time, if the network is very slow to answer.