### PR TITLE
package.json module points to non-existing file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "4.1.9",
     "description": "Reconnecting WebSocket",
     "main": "./dist/reconnecting-websocket-cjs.js",
-    "module": "./dist/reconnecting-websocket.mjs",
+    "module": "./dist/reconnecting-websocket-mjs.js",
     "types": "./dist/reconnecting-websocket.d.ts",
     "scripts": {
         "build": "npm run clean && rollup -c && uglifyjs --compress --mangle -o dist/reconnecting-websocket-iife.min.js dist/reconnecting-websocket-iife.js",


### PR DESCRIPTION
Currently `module` points to `./dist/reconnecting-websocket.mjs`. 

This file doesn't exist. When using the package as a module, import resolution fails with "not a constructor".

This PR points the module to the correct filename.

Probably fixes #101, maybe also #95.