### PR TITLE
WIP: fix: resolve typescript 3.7 errors

### DIFF
--- a/events.ts
+++ b/events.ts
@@ -1,4 +1,20 @@
-export class Event {
+export interface IEvent {
+    target: any;
+    type: string;
+}
+
+export interface IErrorEvent extends IEvent {
+    message: string;
+    error: Error;
+}
+
+export interface ICloseEvent extends IEvent {
+    code: number;
+    reason: string;
+    wasClean: boolean;
+}
+
+export class Event implements IEvent {
     public target: any;
     public type: string;
     constructor(type: string, target: any) {

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -325,8 +325,10 @@ export default class ReconnectingWebSocket {
     }
 
     private _parseUrl(url: unknown): string | Promise<unknown> {
+        // tslint:disable-next-line:ban-types
         const isFunction = (value: unknown): value is Function => typeof value === 'function';
 
+        // tslint:disable-next-line:ban-types
         const isObject = (value: unknown): value is Object =>
             value !== null && value !== undefined && typeof value === 'object';
 

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -352,9 +352,7 @@ export default class ReconnectingWebSocket {
             if (typeof url === 'string') {
                 return Promise.resolve(url);
             }
-            if (url.then) {
-                return url;
-            }
+            return url;
         }
         throw Error('Invalid URL');
     }

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -328,8 +328,7 @@ export default class ReconnectingWebSocket {
         // tslint:disable-next-line:ban-types
         const isFunction = (value: unknown): value is Function => typeof value === 'function';
 
-        // tslint:disable-next-line:ban-types
-        const isObject = (value: unknown): value is Object =>
+        const isObject = (value: unknown): value is object =>
             value !== null && value !== undefined && typeof value === 'object';
 
         const isPromise = (value: unknown): value is Promise<unknown> =>

--- a/test/test.js
+++ b/test/test.js
@@ -462,6 +462,48 @@ test.cb('start closed', t => {
     }, 300);
 });
 
+// FIXME: currently hangs -- needs a defined action on pulling an
+// invalid URL from _getNextUrl
+test.cb.skip('connect with malformed url-provider', t => {
+    const anyMessageText = 'hello';
+    const anyProtocol = 'foobar';
+
+    const wss = new WebSocketServer({port: PORT});
+    wss.on('connection', ws => {
+        t.fail();
+    });
+    wss.on('error', () => {
+        t.fail();
+    });
+
+    t.plan(3);
+
+    // Also reproducible with () => 123
+    const ws = new ReconnectingWebSocket(() => Promise.resolve(123), anyProtocol, {
+        minReconnectionDelay: 100,
+        maxReconnectionDelay: 200,
+    });
+    t.is(ws.readyState, ws.CONNECTING);
+    console.log(1);
+
+    ws.addEventListener('open', () => {
+        t.fail();
+    });
+
+    ws.addEventListener('message', msg => {
+        t.fail();
+    });
+
+    ws.addEventListener('close', () => {
+        t.is(ws.readyState, ws.CLOSED);
+        console.log(2);
+        t.is(ws.url, URL); // TODO
+        console.log(3);
+        wss.close();
+        setTimeout(() => t.end(), 1000);
+    });
+});
+
 test.cb('connect, send, receive, close', t => {
     const anyMessageText = 'hello';
     const anyProtocol = 'foobar';


### PR DESCRIPTION
**Summary**: this request improves upon type-safety for JavaScript users and can iron-out a currently-undefined behavior, but I could use help deciding on the proper behavior to take.



This merge is identical in intent to #113 but takes a different approach.

The differences can be summed up as follows:

- preserve exporting only the type (now interface) of classes `Event`, `ErrorEvent`, and `CloseEvent` (the classes themselves are not exported)
- parse input from program boundaries truthfully

The latter change was necessary because

```
if (url.then) {
    return url;
}
```

in `_getNextUrl` is marked as an error by the typescript compiler as it is a redundant check since `url`'s type-signature `string | Promise<string>`.

However, the `URL provider` test indicates the need for type-safety for the use-case where the calling code is JavaScript, not TypeScript, and thus we cannot be sure that a) `url` is really a `string | Promise<string>` and b) that the `Promise` will resolve with a `string`.

I have added run-time type-checking code in the `_parseUrl` function so that we can always rely on our type signature, but since it is impossible to know what type a Promise will resolve with until it resolves, the type of the Promise returned by `_getNextUrl` was necessarily loosened to `Promise<unknown>` and thus some of this type-checking must be deferred until the Promise resolves in `_connect`.

Here we see the fruits of this exercise as it highlights an inconsistent state with undefined behavior that is possible to reach with the current (published) version of reconnecting-websocket: the `url` returned by `_getNextUrl` may not be a string at all. 

The `URL provider` test ensures that `ws._getNextUrl(123)` and `ws._getNextUrl(123)` both error, but `_getNextUrl` does not handle the case where its argument is a non-string-returning Promise, e.g. `ws._getNextUrl(() => Promise.resolve(123)`, which may certainly come from calling-code written in JavaScript.

The current behavior when `_getNextUrl` resolves a non-string promise is to hang without any message, is also the current behavior of this pull-request. I am currently throwing an error from a chained `then` in `_connect`, but don't know if the best route to take from there is to disconnect, try the next url from `_.getNextUrl` (this may still be problematic if we cycle over the same url indefinitely!) or some other action all-together. I am eager for suggestions and input on this topic.

The advantage of this pull-request over #113 is that we have a chance to define a previously-undefined behavior, at the expense of additional effort. I understand if the decision is to merge in #113, but I would recommend a section added to the Readme detailing that hanging on an unexpected type from the resolved Promise is a known behavior. 