### PR TITLE
gives access to original WebSocket

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -49,7 +49,6 @@ test('global WebSocket is used if available', done => {
     // @ts-ignore
     const ws = new ReconnectingWebSocket(URL, undefined, {maxRetries: 0});
     ws.onerror = () => {
-        // @ts-ignore
         expect(ws._ws instanceof WebSocket).toBe(true);
         done();
     };

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -60,7 +60,7 @@ export type ListenersMap = {
 };
 
 export default class ReconnectingWebSocket {
-    private _ws?: WebSocket;
+    _ws?: WebSocket;
     private _listeners: ListenersMap = {
         error: [],
         message: [],


### PR DESCRIPTION
I would like to get access to the genuine WebSocket object to make use of its `ping` functionality.