### PR TITLE
Add `retryURL` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ type Options = {
     maxRetries?: number; // maximum number of retries
     maxEnqueuedMessages?: number; // maximum number of messages to buffer until reconnection
     startClosed?: boolean; // start websocket in CLOSED state, call `.reconnect()` to connect
+    retryURL: boolean; // retry URL provider request if it fails (it follows the same logic as WebSocket retries)
     debug?: boolean; // enables debug output
 };
 ```
@@ -122,6 +123,7 @@ connectionTimeout: 4000,
 maxRetries: Infinity,
 maxEnqueuedMessages: Infinity,
 startClosed: false,
+retryURL: false,
 debug: false,
 ```
 

--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -595,6 +595,26 @@ test('immediately-failed connection with 0 maxRetries must not retry', done => {
     });
 });
 
+test('failing URL provider is retried if retryURL is true', done => {
+    const ws = new ReconnectingWebSocket(() => Promise.reject(new Error('TEST_ERROR')), undefined, {
+        maxRetries: 2,
+        connectionTimeout: 500,
+        retryURL: true,
+    });
+
+    ws.addEventListener('error', (err: ErrorEvent) => {
+        if (err.message !== 'TEST_ERROR') {
+            throw Error('error');
+        }
+        if (ws.retryCount === 2) {
+            done();
+        }
+        if (ws.retryCount > 2) {
+            throw Error('error');
+        }
+    });
+});
+
 test('connect and close before establishing connection', done => {
     const wss = new WebSocketServer({port: PORT});
     const ws = new ReconnectingWebSocket(URL, undefined, {


### PR DESCRIPTION
Hey!

This adds an option to handle a failure to fetch the WebSocket URL (in case of disconnection) as a legitimate failure that triggers a retry.

This should close: https://github.com/pladaria/reconnecting-websocket/issues/134

What do you think?