### PR TITLE
Add `retryURL` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Reconnecting WebSocket
+# Slite's fork of Reconnecting WebSocket
 
-[![Build Status](https://travis-ci.org/pladaria/reconnecting-websocket.svg?branch=master&v=1)](https://travis-ci.org/pladaria/reconnecting-websocket)
-[![Coverage Status](https://coveralls.io/repos/github/pladaria/reconnecting-websocket/badge.svg?branch=master&v=3)](https://coveralls.io/github/pladaria/reconnecting-websocket?branch=master)
+This is the same as https://github.com/pladaria/reconnecting-websocket but with
+https://github.com/pladaria/reconnecting-websocket/pull/156
 
 WebSocket that will automatically reconnect if the connection is closed.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ type Options = {
     maxRetries?: number; // maximum number of retries
     maxEnqueuedMessages?: number; // maximum number of messages to buffer until reconnection
     startClosed?: boolean; // start websocket in CLOSED state, call `.reconnect()` to connect
+    retryURL: boolean; // retry URL provider request if it fails (it follows the same logic as WebSocket retries)
     debug?: boolean; // enables debug output
 };
 ```
@@ -122,6 +123,7 @@ connectionTimeout: 4000,
 maxRetries: Infinity,
 maxEnqueuedMessages: Infinity,
 startClosed: false,
+retryURL: false,
 debug: false,
 ```
 

--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -595,6 +595,24 @@ test('immediately-failed connection with 0 maxRetries must not retry', done => {
     });
 });
 
+test('failing URL provider is retried if retryURL is true', done => {
+    const ws = new ReconnectingWebSocket(() => Promise.reject(new Error('TEST_ERROR')), undefined, {
+        maxRetries: 2,
+        minReconnectionDelay: 100,
+        maxReconnectionDelay: 200,
+        retryURL: true,
+    });
+
+    ws.addEventListener('error', (err: ErrorEvent) => {
+        if (err.message !== 'TEST_ERROR') {
+            throw Error('error');
+        }
+        if (ws.retryCount === 2) {
+            done();
+        }
+    });
+});
+
 test('connect and close before establishing connection', done => {
     const wss = new WebSocketServer({port: PORT});
     const ws = new ReconnectingWebSocket(URL, undefined, {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "reconnecting-websocket",
-    "version": "4.4.0",
-    "description": "Reconnecting WebSocket",
+    "name": "@slite/reconnecting-websocket",
+    "version": "4.4.1",
+    "description": "Slite's Reconnecting WebSocket",
     "main": "./dist/reconnecting-websocket-cjs.js",
     "module": "./dist/reconnecting-websocket-mjs.js",
     "types": "./dist/reconnecting-websocket.d.ts",
@@ -58,15 +58,15 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/pladaria/reconnecting-websocket.git"
+        "url": "git+https://github.com/sliteteam/reconnecting-websocket.git"
     },
     "bugs": {
-        "url": "https://github.com/pladaria/reconnecting-websocket/issues"
+        "url": "https://github.com/sliteteam/reconnecting-websocket/issues"
     },
     "publishConfig": {
         "registry": "https://registry.npmjs.org"
     },
-    "homepage": "https://github.com/pladaria/reconnecting-websocket#readme",
+    "homepage": "https://github.com/sliteteam/reconnecting-websocket#readme",
     "lint-staged": {
         "linters": {
             "*.{js,md,ts}": [


### PR DESCRIPTION
This is the continuation of https://github.com/pladaria/reconnecting-websocket/pull/152 but using a dedicated branch.

Hey!

This adds an option to handle a failure to fetch the WebSocket URL (in case of disconnection) as a legitimate failure that triggers a retry.

This should close: https://github.com/pladaria/reconnecting-websocket/issues/134

What do you think?