### PR TITLE
Support for Dynamic Protocols

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -178,6 +178,45 @@ test('null websocket protocol', done => {
     });
 });
 
+test('websocket protocols provider', async () => {
+    const anyProtocol = 'foobar';
+    const ws = new ReconnectingWebSocket(URL, undefined, {maxRetries: 0});
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(null)).toBe(null);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(undefined)).toBe(undefined);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(anyProtocol)).toStrictEqual([anyProtocol]);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols([anyProtocol])).toStrictEqual([anyProtocol]);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(() => anyProtocol)).toStrictEqual([anyProtocol]);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(() => [anyProtocol])).toStrictEqual([anyProtocol]);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(() => Promise.resolve(anyProtocol))).toStrictEqual([
+        anyProtocol,
+    ]);
+
+    // @ts-ignore - accessing private property
+    expect(await ws._getNextProtocols(() => Promise.resolve([anyProtocol]))).toStrictEqual([
+        anyProtocol,
+    ]);
+
+    // @ts-ignore - accessing private property
+    expect(() => ws._getNextProtocols(123)).toThrow();
+
+    // @ts-ignore - accessing private property
+    expect(() => ws._getNextProtocols(() => 123)).toThrow();
+});
+
 test('connection status constants', () => {
     const ws = new ReconnectingWebSocket(URL, undefined, {maxRetries: 0});
 

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -420,7 +420,7 @@ export default class ReconnectingWebSocket {
             throw Error('No valid WebSocket class provided');
         }
 
-        let connectionInfo: ConnectionInfo = {};
+        const connectionInfo: ConnectionInfo = {};
 
         this._wait()
             .then(() => this._getNextUrl(this._url))
@@ -436,7 +436,7 @@ export default class ReconnectingWebSocket {
                 if (this._closeCalled) {
                     return;
                 }
-                let {url, protocols} = connectionInfo;
+                const {url, protocols} = connectionInfo;
                 this._debug('connect', {url, protocols});
                 this._ws = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
                 this._ws!.binaryType = this._binaryType;

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -49,6 +49,19 @@ const DEFAULT = {
 };
 
 export type UrlProvider = string | (() => string) | (() => Promise<string>);
+export type ProtocolsProvider =
+    | undefined
+    | null
+    | string
+    | string[]
+    | (() => undefined | null | string | string[])
+    | (() => Promise<undefined | null | string | string[]>)
+    | Promise<undefined | null | string | string[]>;
+
+export type ConnectionInfo = {
+    url?: string;
+    protocols?: undefined | null | string[];
+};
 
 export type Message = string | ArrayBuffer | Blob | ArrayBufferView;
 
@@ -77,10 +90,10 @@ export default class ReconnectingWebSocket {
     private _messageQueue: Message[] = [];
 
     private readonly _url: UrlProvider;
-    private readonly _protocols?: string | string[];
+    private readonly _protocols?: ProtocolsProvider;
     private readonly _options: Options;
 
-    constructor(url: UrlProvider, protocols?: string | string[], options: Options = {}) {
+    constructor(url: UrlProvider, protocols?: ProtocolsProvider, options: Options = {}) {
         this._url = url;
         this._protocols = protocols;
         this._options = options;
@@ -347,6 +360,41 @@ export default class ReconnectingWebSocket {
         throw Error('Invalid URL');
     }
 
+    private _getNextProtocols(
+        protocolsProvider: ProtocolsProvider,
+    ): Promise<undefined | null | string[]> {
+        if (typeof protocolsProvider === 'undefined') {
+            return Promise.resolve(protocolsProvider);
+        }
+
+        if (protocolsProvider === null) {
+            return Promise.resolve(protocolsProvider);
+        }
+
+        if (typeof protocolsProvider === 'string') {
+            return Promise.resolve([protocolsProvider]);
+        }
+
+        if (Array.isArray(protocolsProvider)) {
+            return Promise.resolve(protocolsProvider);
+        }
+
+        // @ts-ignore redundant check
+        if (protocolsProvider.then) {
+            return (protocolsProvider as Promise<ProtocolsProvider>).then(
+                (resolved: ProtocolsProvider) => {
+                    return this._getNextProtocols(resolved);
+                },
+            );
+        }
+
+        if (typeof protocolsProvider === 'function') {
+            return this._getNextProtocols(protocolsProvider() as ProtocolsProvider);
+        }
+
+        throw Error('Invalid Protocols');
+    }
+
     private _connect() {
         if (this._connectLock || !this._shouldReconnect) {
             return;
@@ -371,17 +419,26 @@ export default class ReconnectingWebSocket {
         if (!isWebSocket(WebSocket)) {
             throw Error('No valid WebSocket class provided');
         }
+
+        let connectionInfo: ConnectionInfo = {};
+
         this._wait()
             .then(() => this._getNextUrl(this._url))
             .then(url => {
+                connectionInfo.url = url;
+            })
+            .then(() => this._getNextProtocols(this._protocols))
+            .then(protocols => {
+                connectionInfo.protocols = protocols;
+            })
+            .then(() => {
                 // close could be called before creating the ws
                 if (this._closeCalled) {
                     return;
                 }
-                this._debug('connect', {url, protocols: this._protocols});
-                this._ws = this._protocols
-                    ? new WebSocket(url, this._protocols)
-                    : new WebSocket(url);
+                let {url, protocols} = connectionInfo;
+                this._debug('connect', {url, protocols});
+                this._ws = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
                 this._ws!.binaryType = this._binaryType;
                 this._connectLock = false;
                 this._addListeners();


### PR DESCRIPTION
Issue [#162].

Feature:
Dynamically provide Protocols on reconnect.

Use case:
Protocols is the only mechanism available to WebSocket to pass initialization information to the backend at connection time. As such, this could be leveraged for authorization. Modern authorization mechanisms, such as tokens, rotate over time and reconnecting with an old token will eventually fail. A dynamic Protocols provider can produce valid tokens at reconnect time.