### PR TITLE
Fix: handle error if getNextUrl throws

### DIFF
--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -387,7 +387,11 @@ export default class ReconnectingWebSocket {
                 this._addListeners();
 
                 this._connectTimeout = setTimeout(() => this._handleTimeout(), connectionTimeout);
-            });
+            })
+            .catch(err => {
+                this._connectLock = false;
+                this._handleError(new Events.ErrorEvent(Error(err.message), this))
+            })
     }
 
     private _handleTimeout() {


### PR DESCRIPTION
## Problem
If getNextUrl throws an error, the websocket will never be able to reconnect again. For example:

```
async () => {
    const token = await getToken()
    return baseUrl + token
},
```

This is because `_connect()` has no `catch` to reset `_connectLock`.

## Fix
This simply adds a catch to reset `_connectLock` and handle the error like any other.