### PR TITLE
fix: only close open websocket on disconnect

### DIFF
--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -402,7 +402,9 @@ export default class ReconnectingWebSocket {
         }
         this._removeListeners();
         try {
-            this._ws.close(code, reason);
+             if (this._ws.readyState === this.OPEN) {
+                this._ws.close(code, reason);
+            }
             this._handleClose(new Events.CloseEvent(code, reason, this));
         } catch (error) {
             // ignore


### PR DESCRIPTION
Related to #183 
When reconnecting-websocket encounters a timeout during the connecting phase, `_disconnect` wants to close the websocket. This results in the websocket error "WebSocket was closed before the connection was established" being thrown, because the websocket is still in the `CONNECTING` state.
This fix allows it to retry the connection after the timeout instead of throwing and ending the connection.